### PR TITLE
compiler.parser warning in webpack 2.2.1 fixed

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,48 +42,50 @@ I18nPlugin.prototype.apply = function(compiler) {
 		compilation.dependencyFactories.set(ConstDependency, new NullFactory());
 		compilation.dependencyTemplates.set(ConstDependency, new ConstDependency.Template());
 	});
-	compiler.parser.plugin("call " + this.functionName, function(expr) {
-		var param, defaultValue;
-		switch(expr.arguments.length) {
-		case 2:
-			param = this.evaluateExpression(expr.arguments[1]);
-			if(!param.isString()) return;
-			param = param.string;
-			defaultValue = this.evaluateExpression(expr.arguments[0]);
-			if(!defaultValue.isString()) return;
-			defaultValue = defaultValue.string;
-			break;
-		case 1:
-			param = this.evaluateExpression(expr.arguments[0]);
-			if(!param.isString()) return;
-			defaultValue = param = param.string;
-			break;
-		default:
-			return;
-		}
-		var result = localization ? localization(param) : defaultValue;
-		if(typeof result == "undefined") {
-			if (!hideMessage) {
-				var error = this.state.module[__dirname];
-				if(!error) {
-					error = this.state.module[__dirname] = new MissingLocalizationError(this.state.module, param, defaultValue);
-					if (failOnMissing) {
-						this.state.module.errors.push(error);
-					} else {
-						this.state.module.warnings.push(error);
-					}
-				} else if(error.requests.indexOf(param) < 0) {
-					error.add(param, defaultValue);
+	var that = this;
+	compiler.plugin("compilation", function(compilation, data) {
+		data.normalModuleFactory.plugin("parser", function(parser, options) {
+			parser.plugin("call " + that.functionName, function(expr) {
+				var param, defaultValue;
+				switch(expr.arguments.length) {
+				case 2:
+					param = this.evaluateExpression(expr.arguments[1]);
+					if(!param.isString()) return;
+					param = param.string;
+					defaultValue = this.evaluateExpression(expr.arguments[0]);
+					if(!defaultValue.isString()) return;
+					defaultValue = defaultValue.string;
+					break;
+				case 1:
+					param = this.evaluateExpression(expr.arguments[0]);
+					if(!param.isString()) return;
+					defaultValue = param = param.string;
+					break;
+				default:
+					return;
 				}
-			}
-			result = defaultValue;
-		}
-		var dep = new ConstDependency(JSON.stringify(result), expr.range);
-		dep.loc = expr.loc;
-		this.state.current.addDependency(dep);
-		return true;
+				var result = localization ? localization(param) : defaultValue;
+				if(typeof result == "undefined") {
+					var error = this.state.module[__dirname];
+					if(!error) {
+						error = this.state.module[__dirname] = new MissingLocalizationError(this.state.module, param, defaultValue);
+						if (failOnMissing) {
+							this.state.module.errors.push(error);
+						} else {
+							this.state.module.warnings.push(error);
+						}
+					} else if(error.requests.indexOf(param) < 0) {
+						error.add(param, defaultValue);
+					}
+					result = defaultValue;
+				}
+				var dep = new ConstDependency(JSON.stringify(result), expr.range);
+				dep.loc = expr.loc;
+				this.state.current.addDependency(dep);
+				return true;
+			});
+		});
 	});
-
 };
 
 /**


### PR DESCRIPTION
1) webpack: Using compiler.parser is deprecated warning in webpack 2.2.1 fixed by replacing 
```
compiler.parser.plugin("call " + this.functionName, function(expr) {
```
```
compiler.plugin("compilation", function(compilation, data) {
		data.normalModuleFactory.plugin("parser", function(parser, options) {
			parser.plugin("call " + that.functionName, function(expr) {
```