### PR TITLE
fix: hide warnings if options.hideMessage is truthy

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,7 +71,7 @@ I18nPlugin.prototype.apply = function(compiler) {
 						error = this.state.module[__dirname] = new MissingLocalizationError(this.state.module, param, defaultValue);
 						if (failOnMissing) {
 							this.state.module.errors.push(error);
-						} else {
+						} else if (!hideMessage) {
 							this.state.module.warnings.push(error);
 						}
 					} else if(error.requests.indexOf(param) < 0) {


### PR DESCRIPTION
This fixes #44, which seems to have broken after a refactoring.

Closes #44