### PR TITLE
feat: allow template strings

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -83,9 +83,9 @@ class I18nPlugin {
             }
             result = defaultValue;
           }
-          
+
           result = JSON.stringify(result);
-          result = result.replace(/^"`(.*)`"$/, "`$1`");
+          result = result.replace(/^"`(.*)`"$/, '`$1`');
 
           const dep = new ConstDependency(result, expr.range);
           dep.loc = expr.loc;

--- a/src/index.js
+++ b/src/index.js
@@ -83,8 +83,11 @@ class I18nPlugin {
             }
             result = defaultValue;
           }
+          
+          result = JSON.stringify(result);
+          result = result.replace(/^"`(.*)`"$/, "`$1`");
 
-          const dep = new ConstDependency(JSON.stringify(result), expr.range);
+          const dep = new ConstDependency(result, expr.range);
           dep.loc = expr.loc;
           this.state.current.addDependency(dep);
           return true;

--- a/test/cases/__snapshots__/apply-translations.test.js.snap
+++ b/test/cases/__snapshots__/apply-translations.test.js.snap
@@ -5,5 +5,6 @@ Object {
   "defaults": "default value",
   "missingKey": "missing-key2",
   "staticKey": "translated static key",
+  "templateString": "Your dynamic value is some value.",
 }
 `;

--- a/test/cases/apply-translations.code.js
+++ b/test/cases/apply-translations.code.js
@@ -1,4 +1,6 @@
 /* globals __ */
+// Define the variable to be used in the template string during translation:
+const variableForTemplateString = 'some value'; // eslint-disable-line no-unused-vars
 exports.defaults = __('default value', 'missing-key1');
 exports.missingKey = __('missing-key2');
 exports.staticKey = __('static-key');

--- a/test/cases/apply-translations.code.js
+++ b/test/cases/apply-translations.code.js
@@ -2,3 +2,4 @@
 exports.defaults = __('default value', 'missing-key1');
 exports.missingKey = __('missing-key2');
 exports.staticKey = __('static-key');
+exports.templateString = __('template-string');

--- a/test/cases/apply-translations.test.js
+++ b/test/cases/apply-translations.test.js
@@ -1,3 +1,6 @@
+/* eslint-disable
+  no-template-curly-in-string,
+*/
 import processFile from '../cases.setup';
 
 describe('apply-translations', () => {
@@ -6,7 +9,7 @@ describe('apply-translations', () => {
   beforeAll(() => {
     const translations = {
       'static-key': 'translated static key',
-      'template-string': '`Your dynamic value is ${variableForTemplateString}.`', // eslint-disable-line no-template-curly-in-string
+      'template-string': '`Your dynamic value is ${variableForTemplateString}.`',
     };
 
     return processFile('apply-translations.code.js', translations)

--- a/test/cases/apply-translations.test.js
+++ b/test/cases/apply-translations.test.js
@@ -6,6 +6,7 @@ describe('apply-translations', () => {
   beforeAll(() => {
     const translations = {
       'static-key': 'translated static key',
+      'template-string': '`Your dynamic value is ${variableForTemplateString}.`', // eslint-disable-line no-template-curly-in-string
     };
 
     return processFile('apply-translations.code.js', translations)


### PR DESCRIPTION
This change allows the use of template strings with variables within translated configurations.  It looks for translations that explicitly begin with:
```
"`
```
and end with
```
`"
```

Configuration JSON:
```
{
  "HelloMessage": "`Hello ${userName}`"
}
```
Usage:
```
const userName = 'International User';
const message = __('HelloMessage');
```

Expected output when rendering message:
`Hello International User`

<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->
