### PR TITLE
refactor:  i18n Webpack Plugin Webpack 4.x compatibility

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,7 +5,7 @@
       {
         "useBuiltIns": true,
         "targets": {
-          "node": "6"
+          "node": "6.9.0"
         },
         "exclude": [
           "transform-async-to-generator",

--- a/.babelrc
+++ b/.babelrc
@@ -5,7 +5,7 @@
       {
         "useBuiltIns": true,
         "targets": {
-          "node": "4.3"
+          "node": "6"
         },
         "exclude": [
           "transform-async-to-generator",

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,18 +4,16 @@ language: node_js
 branches:
   only:
     - master
+    - next
 jobs:
   fast_finish: true
   allow_failures:
     - env: WEBPACK_VERSION=canary
+    - node_js: 9
   include:
     - &test-latest
       stage: Webpack latest
       node_js: 6
-      env: WEBPACK_VERSION=latest JOB_PART=test
-      script: npm run travis:$JOB_PART
-    - <<: *test-latest
-      node_js: 4.8
       env: WEBPACK_VERSION=latest JOB_PART=test
       script: npm run travis:$JOB_PART
     - <<: *test-latest
@@ -30,6 +28,10 @@ jobs:
     - stage: Webpack canary
       node_js: 8
       env: WEBPACK_VERSION=4.0.0-alpha.0 JOB_PART=test
+      script: npm run travis:$JOB_PART
+    - stage: NodeJS Next
+      node_js: 9
+      env: WEBPACK_VERSION=latest JOB_PART=test
       script: npm run travis:$JOB_PART
 before_install:
   - 'if [[ `npm -v` != 5* ]]; then npm i -g npm@^5.0.0; fi'

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,11 @@ jobs:
   include:
     - &test-latest
       stage: Webpack latest
-      nodejs: 6
+      node_js: 6
       env: WEBPACK_VERSION=latest JOB_PART=test
       script: npm run travis:$JOB_PART
     - <<: *test-latest
-      nodejs: 4.3
+      node_js: 4.8
       env: WEBPACK_VERSION=latest JOB_PART=test
       script: npm run travis:$JOB_PART
     - <<: *test-latest
@@ -28,10 +28,9 @@ jobs:
       script: npm run travis:$JOB_PART
       after_success: 'bash <(curl -s https://codecov.io/bash)'
     - stage: Webpack canary
-      before_script: npm i --no-save git://github.com/webpack/webpack.git#master
-      script: npm run travis:$JOB_PART
       node_js: 8
-      env: WEBPACK_VERSION=canary JOB_PART=test
+      env: WEBPACK_VERSION=4.0.0-alpha.0 JOB_PART=test
+      script: npm run travis:$JOB_PART
 before_install:
   - 'if [[ `npm -v` != 5* ]]; then npm i -g npm@^5.0.0; fi'
   - nvm --version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,22 +6,23 @@ init:
 environment:
   matrix:
     - nodejs_version: '8'
-      webpack_version: 2.6.0
+      webpack_version: latest
       job_part: test
     - nodejs_version: '6'
-      webpack_version: 2.6.0
+      webpack_version: latest
       job_part: test
-    - nodejs_version: '4.3'
-      webpack_version: 2.6.0
+    - nodejs_version: '8'
+      webpack_version: 4.0.0-alpha.0
       job_part: test
 build: 'off'
 matrix:
   fast_finish: true
 install:
   - ps: Install-Product node $env:nodejs_version x64
+  - npm i -g npm@latest
   - npm install
 before_test:
-  - cmd: npm install webpack@^%webpack_version%
+  - cmd: npm install webpack@%webpack_version%
 test_script:
   - node --version
   - npm --version

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "webpack": "^3.0.0 || ^4.0.0-alpha.0 || ^4.0.0"
   },
   "engines": {
-    "node": ">= 6 || >= 8"
+    "node": ">= 6.9.0 || >= 8.9.0"
   },
   "homepage": "https://webpack.js.org",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -48,10 +48,10 @@
     "webpack-defaults": "^1.4.0"
   },
   "peerDependencies": {
-    "webpack": "^2.0.0 || >= 3.0.0-rc.0 || ^3.0.0"
+    "webpack": "^3.0.0 || ^4.0.0-alpha.0 || ^4.0.0"
   },
   "engines": {
-    "node": ">= 4.3 < 5.0.0 || >= 5.10"
+    "node": ">= 6 || >= 8"
   },
   "homepage": "https://webpack.js.org",
   "repository": {


### PR DESCRIPTION
<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->
- Fixes for Webpack 4.x
- Drops support for NodeJS 4.x
- Sets minimum peerDep to Webpack 3.x

BREAKING CHANGE: Sets `engines` to `"node": ">= 6.9.0 || >= 8.9.0"`
BREAKING CHANGE: Drops support for Webpack `v2.x`