### PR TITLE
feat: callback on missing localization

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -31,10 +31,11 @@ class I18nPlugin {
     this.functionName = this.options.functionName || '__';
     this.failOnMissing = !!this.options.failOnMissing;
     this.hideMessage = this.options.hideMessage || false;
+    this.missingLocalizationCallback = this.options.missingLocalizationCallback || (() => 0);
   }
 
   apply(compiler) {
-    const { localization, failOnMissing, hideMessage } = this; // eslint-disable-line no-unused-vars
+    const { localization, failOnMissing, hideMessage, missingLocalizationCallback } = this; // eslint-disable-line no-unused-vars
     const name = this.functionName;
 
     compiler.plugin('compilation', (compilation, params) => { // eslint-disable-line no-unused-vars
@@ -68,6 +69,7 @@ class I18nPlugin {
           let result = localization ? localization(param) : defaultValue;
 
           if (typeof result === 'undefined') {
+            missingLocalizationCallback(param, this.state.module);
             let error = this.state.module[__dirname];
             if (!error) {
               error = new MissingLocalizationError(this.state.module, param, defaultValue);

--- a/test/cases/opts-missing-localization-callback.code.js
+++ b/test/cases/opts-missing-localization-callback.code.js
@@ -1,0 +1,3 @@
+/* globals __ */
+exports.missingKey = __('missing-key');
+exports.existingKey = __('existing-key');

--- a/test/cases/opts-missing-localization-callback.test.js
+++ b/test/cases/opts-missing-localization-callback.test.js
@@ -1,0 +1,14 @@
+import processFile from '../cases.setup';
+
+describe('options.missingLocalizationCallback', () => {
+  it('should should call the callback once', () => {
+    const translations = { 'existing-key': 'existing-value' };
+    const missingLocalizationCallback = jest.fn();
+    const options = {
+      missingLocalizationCallback,
+    };
+
+    return processFile('opts-missing-localization-callback.code.js', translations, options)
+    .then(() => expect(missingLocalizationCallback).toHaveBeenCalledTimes(1));
+  });
+});


### PR DESCRIPTION
<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->
I want to add a callback, so that instead of just sending missing localization errors I can, for instance, add the terms to a file.