### PR TITLE
docs(README): add documentation for `nested` option (`options.nested`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ plugins: [
  - `optionsObj.functionName`: the default value is `__`, you can change it to other function name.
  - `optionsObj.failOnMissing`: the default value is `false`, which will show a warning message, if the mapping text cannot be found. If set to `true`, the message will be an error message.
  - `optionsObj.hideMessage`: the default value is `false`, which will show the warning/error message. If set to `true`, the message will be hidden.
+ - `optionsObj.nested`: the default value is `false`. If set to `true`, the keys in `languageConfig` can be nested. This option is interpreted only if `languageConfig` isn't a function.
 
 <h2 align="center">Maintainers</h2>
 


### PR DESCRIPTION
I expected the `nested` option to be truthy by default and ran into a problem which could be resolved by reading that: https://github.com/webpack-contrib/i18n-webpack-plugin/issues/16#issuecomment-319685256

Here's the missing documentation.